### PR TITLE
BREAKING CHANGE: Drop support for Node 6 & 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-  - 6
-  - 7
   - 8
   - 9
   - 10
+  - 11
+  - 12
 cache: npm
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "statuses": "^1.4.0"
   },
   "devDependencies": {
-    "ava": "^1.0.0",
+    "ava": "^2.0.0",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "^5.0.0",
-    "eslint-plugin-ava": "^6.0.0",
+    "eslint-plugin-ava": "^7.0.0",
     "husky": "^2.0.0",
     "nps": "^5.7.1",
     "nyc": "^14.0.0",


### PR DESCRIPTION
- NodeJS 6 & 7 have both reached end of life,
  as such support has been dropped for both of them.